### PR TITLE
create stripe customer account for non-sitter

### DIFF
--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -37,6 +37,10 @@ const profileSchema = new mongoose.Schema(
       type: String,
       default: '',
     },
+    stripeCustomerId: {
+      type: String,
+      default: ''
+    }
   },
   options
 );

--- a/server/utils/stripe.js
+++ b/server/utils/stripe.js
@@ -7,7 +7,7 @@ const CURRENCY = 'usd';
 exports.createStripeCustomer = async (booking) => {
   const user = await User.findById(booking.userId);
   const { name, email } = user;
-  const customer = await stripe.create({
+  const customer = await stripe.customers.create({
     name: name,
     email: email,
   });


### PR DESCRIPTION
### What this PR does (required):
- PR for #17 
- When a customer signs up, creates a Stripe customer record
- adds a new field to the Profile document to save the Stripe customer id
- fixes `stripe.create` method call

### Any information needed to test this feature (required):
- Post to `http://localhost:3001/auth/register` with body:
```json
{
  "name": "sitter17",
  "email": "sitter17@test.com",
  "password": "Secret1234%"
}
```
- Expect the post call to not fail
- Expect to see a new profile with a real Stripe customer Id

### Any issues with the current functionality (optional):
- I think this should be a separate method other than signup
